### PR TITLE
Update README with explicit clone URL

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -23,7 +23,7 @@
 
 1. **リポジトリをクローン**
    ```bash
-   git clone <repository-url>
+   git clone https://github.com/kohei3110/gh-copilot-multirepo-demo-backend.git
    cd gh-copilot-multirepo-demo-backend
    ```
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The project showcases how to use Copilot Orchestra to orchestrate multiple AI ag
 
 1. **Clone the repository**
    ```bash
-   git clone <repository-url>
+   git clone https://github.com/kohei3110/gh-copilot-multirepo-demo-backend.git
    cd gh-copilot-multirepo-demo-backend
    ```
 


### PR DESCRIPTION
Update the cloning instructions in the README to specify the repository's URL explicitly.